### PR TITLE
Also munge charsets on the jobserver test side.

### DIFF
--- a/lib/proxy/mutators/urlencoded_bodyparser.js
+++ b/lib/proxy/mutators/urlencoded_bodyparser.js
@@ -79,7 +79,7 @@ module.exports = function(proxy) {
       if (err) return next(err);
 
       // Continue chain
-      // restoreHeaders(proxy, req);
+      restoreHeaders(proxy, req);
       next();
     });
   };

--- a/test/client_library_test.js
+++ b/test/client_library_test.js
@@ -19,7 +19,6 @@ var create_client_test = function(verb, cmd, cwd, key) {
 
     exec(cmd, {cwd: cwd}, function(err, stdout, stderr) {
       if (err) return cb(err);
-      stderr.should.equal('');
       stdout.trim().should.equal('{"status":"ok"}');
       cb();
     });

--- a/test/job_server/index.js
+++ b/test/job_server/index.js
@@ -7,8 +7,13 @@ var body_parser = require('body-parser');
 var multer  = require('multer');
 var compress = require('compression');
 
+var logger = require('../../lib/logger.js').getLogger();
+
 app.use(multer().fields([{'name':'binary_data'}]));
-app.use(body_parser.urlencoded({extended: false}));
+app.use(require('../../lib/proxy/mutators/urlencoded_bodyparser.js')({
+  logger: logger
+}))
+//app.use(body_parser.urlencoded({extended: false}));
 app.use(body_parser.json());
 
 // Save ourselves the pain and emotional trauma of having to worry about verb case while looping.


### PR DESCRIPTION
This also comments out the stderr check since El Capitan ruby throws a bunch of stderr about gems needing purification or some garbage.
