### PR TITLE
Set the proper agent for outbound requests.

### DIFF
--- a/lib/proxy/index.js
+++ b/lib/proxy/index.js
@@ -231,7 +231,7 @@ Proxy.prototype.getConnectApp = function() {
     // If no agent is provided, node-http-proxy will return a connection: close.
     app.use(function(req, res) {
 
-      var agent = req.parsed_url.protocol === 'https:' ? HTTPS_AGENT : HTTP_AGENT;
+      var agent = url.parse(req.target_url).protocol === 'https:' ? HTTPS_AGENT : HTTP_AGENT;
 
       this_obj.logger.debug(module_tag, 'headers:\n%s', require('util').inspect(req.headers));
       this_obj.logger.debug(module_tag, 'target_url: %s', req.target_url);


### PR DESCRIPTION
This resolves the outbound failures.
